### PR TITLE
Play all parts fix.

### DIFF
--- a/plugin.video.uwc/resources/lib/sites/paradisehill.py
+++ b/plugin.video.uwc/resources/lib/sites/paradisehill.py
@@ -123,7 +123,7 @@ def Playvid(url, name, download=None):
                 listitem = xbmcgui.ListItem(newname, iconImage="DefaultVideo.png", thumbnailImage=iconimage)
                 listitem.setInfo('video', {'Title': newname, 'Genre': 'Porn'})
                 listitem.setProperty("IsPlayable","true")
-                videourl = videourl + "|referer="+ url
+                videourl = "https:" + videourl
                 pl.add(videourl, listitem)
                 i += 1
                 listitem = ''


### PR DESCRIPTION
When "Paradisehill -> Play all parts (no download)" was enabled under general settings, videos wouldn't play.
Corrrected this, video parts will now play consecutively.