### PR TITLE
use html.unescape over deprecated and now removed HTMLParser.unescape…

### DIFF
--- a/plugin.video.cumination/resources/lib/utils.py
+++ b/plugin.video.cumination/resources/lib/utils.py
@@ -620,8 +620,12 @@ def parse_query(query):
 
 
 def cleantext(text):
-    h = html_parser.HTMLParser()
-    text = h.unescape(text) if PY3 else h.unescape(text.decode('utf8')).encode('utf8')
+    if PY3:
+        import html
+        text = html.unescape(text)
+    else:
+        h = html_parser.HTMLParser()
+        text = h.unescape(text.decode('utf8')).encode('utf8')
     text = text.replace('&amp;', '&')
     text = text.replace('&apos;', "'")
     text = text.replace('&lt;', '<')


### PR DESCRIPTION
This fixes the following error in Python 3.9.2 on arch linux

```
File "/home/username/.kodi/addons/plugin.video.cumination/resources/lib/utils.py", line 624, in cleantext
     text = h.unescape(text) if PY3 else h.unescape(text.decode('utf8')).encode('utf8')
 AttributeError: 'HTMLParser' object has no attribute 'unescape'
```

I think in python 3.9 the unescape method was removed. I haven't tested this with earlier versions of python.