### PR TITLE
Cumination favorites: prevent video list refresh on add

### DIFF
--- a/plugin.video.cumination/resources/lib/favorites.py
+++ b/plugin.video.cumination/resources/lib/favorites.py
@@ -161,6 +161,7 @@ def Favorites(fav, favmode, name, url, img, duration='', quality=''):
         else:
             addFav(favmode, name, url, img, duration, quality)
             utils.notify('Favorite added', 'Video added to the favorites')
+        return
     elif fav == "del":
         delFav(url)
         utils.notify('Favorite deleted', 'Video removed from the list')


### PR DESCRIPTION
When browsing videos / webcams, prevent an useless refresh that can lose the current position (especially for webcams lists): on add, we're not on the favorites view (which is the one that would require refresh)