### PR TITLE
Porndig video player fix

### DIFF
--- a/plugin.video.cumination/changelog.txt
+++ b/plugin.video.cumination/changelog.txt
@@ -1,4 +1,2 @@
-[B]Version 1.1.93[/B]
-- chaturbate enable online favourites menu
-- rule34 tags fix and add categories menu
-- hpjav fix listing and playback
+[B]Version 1.1.94[/B]
+- porndig videoplayer fix

--- a/plugin.video.cumination/resources/lib/sites/porndig.py
+++ b/plugin.video.cumination/resources/lib/sites/porndig.py
@@ -223,7 +223,7 @@ def Playvid(url, name, download=None):
     vp = utils.VideoPlayer(name, download)
     vp.progress.update(25, "[CR]Loading video page[CR]")
     videopage = utils.getHtml(url, site.url)
-    player = re.compile(r'<iframe.+?class=""\s*src="([^"]+)"', re.DOTALL | re.IGNORECASE).findall(videopage)
+    player = re.compile(r'<iframe.+?data-url.+?class.+?src="([^"]+)"', re.DOTALL | re.IGNORECASE).findall(videopage)
     if player:
         playerpage = utils.getHtml(player[0], url)
     else:


### PR DESCRIPTION
Porndig has changed the iframe of it`s video player, which resulted in a graceful exit of the porndig site definition.
This fixes this and plays porndig video sources again.