### PR TITLE
chaturbate - proxy chunklists for session reconnect + graceful stop

### DIFF
--- a/plugin.video.cumination/resources/lib/sites/chaturbate.py
+++ b/plugin.video.cumination/resources/lib/sites/chaturbate.py
@@ -290,6 +290,18 @@ def Playvid(url, name):
                     r'URI="(?!https?://)(.*?)"',
                     lambda m: 'URI="' + _urljoin(base, m.group(1)) + '"',
                     master_fixed, flags=re.IGNORECASE)
+                # Debug log for proxy events (toggle via Settings > enh_debug)
+                _dbg_path = os.path.join(utils.TRANSLATEPATH('special://temp'), 'cb_proxy.log')
+                _dbg_on = addon.getSetting('enh_debug') == 'true'
+                def _dbg(msg):
+                    if not _dbg_on:
+                        return
+                    try:
+                        with open(_dbg_path, 'a') as f:
+                            f.write('{} {}\n'.format(time.strftime('%H:%M:%S'), msg))
+                    except Exception:
+                        pass
+
                 # Bind proxy port first so we can rewrite chunklist URLs
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 sock.bind(('127.0.0.1', 0))
@@ -316,6 +328,7 @@ def Playvid(url, name):
                     _km = re.search(r'(chunklist_\d+_\w+)', _mi.group(1))
                     if _km:
                         _proxy_state['url_map'][_km.group(1)] = _mi.group(1)
+                _dbg('PROXY START port={} keys={}'.format(port, list(_proxy_state['url_map'].keys())))
 
                 # Rewrite only .m3u8 chunklist URLs to go through our proxy
                 # (leave init segments / .m4s files as direct CDN URLs)
@@ -361,8 +374,10 @@ def Playvid(url, name):
                                 new_map[km.group(1)] = mi.group(1)
                         with _proxy_state['lock']:
                             _proxy_state['url_map'].update(new_map)
+                        _dbg('REFRESH OK new_keys={}'.format(list(new_map.keys())))
                         return True
-                    except Exception:
+                    except Exception as e:
+                        _dbg('REFRESH FAIL {}'.format(e))
                         return False
 
                 # Localhost proxy: serves master + proxies chunklists with auto-reconnect
@@ -402,12 +417,13 @@ def Playvid(url, name):
                                 self.send_header('Content-Length', str(len(data)))
                                 self.end_headers()
                                 self.wfile.write(data)
-                            except Exception:
+                            except Exception as e:
                                 # CDN session died — retry reconnect for up to 30s
-                                # (covers stream switches where new origin takes a moment)
+                                _dbg('CHUNKLIST FAIL type={} err={}'.format(type_key, e))
                                 reconnected = False
                                 if type_key:
                                     for _attempt in range(6):
+                                        _dbg('RECONNECT attempt={}/6 type={}'.format(_attempt + 1, type_key))
                                         time.sleep(5)
                                         if _refresh_session():
                                             new_url = _proxy_state['url_map'].get(type_key)
@@ -420,11 +436,12 @@ def Playvid(url, name):
                                                     self.end_headers()
                                                     self.wfile.write(data)
                                                     reconnected = True
+                                                    _dbg('RECONNECT OK attempt={} type={}'.format(_attempt + 1, type_key))
                                                     break
-                                                except Exception:
-                                                    pass
+                                                except Exception as e2:
+                                                    _dbg('RECONNECT FETCH FAIL attempt={} err={}'.format(_attempt + 1, e2))
                                 if not reconnected:
-                                    # All retries exhausted — force stop playback
+                                    _dbg('GIVING UP type={} — stopping playback'.format(type_key))
                                     if not _proxy_state.get('stopping'):
                                         _proxy_state['stopping'] = True
                                         try:

--- a/plugin.video.cumination/resources/lib/sites/chaturbate.py
+++ b/plugin.video.cumination/resources/lib/sites/chaturbate.py
@@ -35,6 +35,7 @@ site = AdultSite('chaturbate', '[COLOR hotpink]Chaturbate[/COLOR]', bu, 'chaturb
 
 addon = utils.addon
 _cb_proxy = None
+_cb_proxy_state = None
 HTTP_HEADERS_IPAD = {'User-Agent': 'Mozilla/5.0 (iPad; CPU OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B410 Safari/600.1.4'}
 
 
@@ -267,17 +268,40 @@ def Playvid(url, name):
             from six.moves.urllib.parse import urljoin as _urljoin
 
             try:
-                global _cb_proxy
+                global _cb_proxy, _cb_proxy_state
+
+                # Debug log for proxy events (toggle via Settings > enh_debug)
+                _dbg_path = os.path.join(utils.TRANSLATEPATH('special://temp'), 'cb_proxy.log')
+                _dbg_on = addon.getSetting('enh_debug') == 'true'
+                def _dbg(msg):
+                    if not _dbg_on:
+                        return
+                    try:
+                        with open(_dbg_path, 'a') as f:
+                            f.write('{} {}\n'.format(time.strftime('%H:%M:%S'), msg))
+                    except Exception:
+                        pass
+
+                # Signal the previous stream's monitor/reconnect threads to exit
+                # so the old srv reference doesn't keep the old proxy alive.
+                if _cb_proxy_state is not None:
+                    _dbg('CLEANUP: signalling old state stopping=True')
+                    _cb_proxy_state['stopping'] = True
+                    _cb_proxy_state = None
 
                 if _cb_proxy is not None:
+                    _dbg('CLEANUP: shutting down previous proxy {}'.format(
+                        getattr(_cb_proxy, 'server_address', '?')))
                     try:
                         _cb_proxy.shutdown()
-                    except Exception:
-                        pass
+                        _dbg('CLEANUP: shutdown() OK')
+                    except Exception as cex1:
+                        _dbg('CLEANUP: shutdown() FAILED: {}'.format(cex1))
                     try:
                         _cb_proxy.server_close()
-                    except Exception:
-                        pass
+                        _dbg('CLEANUP: server_close() OK')
+                    except Exception as cex2:
+                        _dbg('CLEANUP: server_close() FAILED: {}'.format(cex2))
                     _cb_proxy = None
 
                 headers = HTTP_HEADERS_IPAD.copy()
@@ -294,17 +318,6 @@ def Playvid(url, name):
                     r'URI="(?!https?://)(.*?)"',
                     lambda m: 'URI="' + _urljoin(base, m.group(1)) + '"',
                     master_fixed, flags=re.IGNORECASE)
-                # Debug log for proxy events (toggle via Settings > enh_debug)
-                _dbg_path = os.path.join(utils.TRANSLATEPATH('special://temp'), 'cb_proxy.log')
-                _dbg_on = addon.getSetting('enh_debug') == 'true'
-                def _dbg(msg):
-                    if not _dbg_on:
-                        return
-                    try:
-                        with open(_dbg_path, 'a') as f:
-                            f.write('{} {}\n'.format(time.strftime('%H:%M:%S'), msg))
-                    except Exception:
-                        pass
 
                 # Bind proxy port first so we can rewrite chunklist URLs
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -381,7 +394,13 @@ def Playvid(url, name):
                                 new_map[km.group(1)] = mi.group(1)
                         with _proxy_state['lock']:
                             _proxy_state['url_map'].update(new_map)
-                        _dbg('REFRESH OK new_keys={}'.format(list(new_map.keys())))
+                            # Invalidate cached chunklists and segment maps so the
+                            # next ISA request pulls a fresh chunklist with the new
+                            # JWT session instead of serving stale dead-segment bodies.
+                            _proxy_state['chunklist_cache'].clear()
+                            _proxy_state['seg_cdn_urls'].clear()
+                            _proxy_state['latest_seg'].clear()
+                        _dbg('REFRESH OK new_keys={} caches_cleared'.format(list(new_map.keys())))
                         return True
                     except Exception as e:
                         _dbg('REFRESH FAIL {}'.format(e))
@@ -407,33 +426,55 @@ def Playvid(url, name):
                         _dbg('close err: {}'.format(sex))
 
                 def _bg_reconnect():
+                    needs_force_stop = True
                     try:
                         for _attempt in range(15):
                             if _proxy_state.get('stopping'):
                                 _dbg('RECONNECT aborted - proxy stopping')
+                                needs_force_stop = False
                                 return
                             _dbg('RECONNECT attempt={}/15'.format(_attempt + 1))
                             if _refresh_session():
                                 _dbg('RECONNECT OK attempt={}'.format(_attempt + 1))
                                 with _proxy_state['lock']:
                                     _proxy_state['reconnecting'] = False
-                                _dbg('WATCHDOG waiting 5s to check ISA')
-                                time.sleep(5)
+                                _dbg('WATCHDOG waiting 8s to check ISA')
+                                time.sleep(8)
                                 if _proxy_state.get('stopping'):
+                                    needs_force_stop = False
                                     return
                                 gap = time.time() - _proxy_state.get('last_request', 0)
                                 _dbg('WATCHDOG gap={:.1f}s'.format(gap))
-                                if gap > 4:
-                                    _force_stop('ISA went silent {:.0f}s after reconnect'.format(gap))
+                                if gap > 6:
+                                    _dbg('WATCHDOG over threshold, rechecking in 3s')
+                                    time.sleep(3)
+                                    if _proxy_state.get('stopping'):
+                                        needs_force_stop = False
+                                        return
+                                    gap2 = time.time() - _proxy_state.get('last_request', 0)
+                                    _dbg('WATCHDOG recheck gap={:.1f}s'.format(gap2))
+                                    if gap2 > 6:
+                                        needs_force_stop = False
+                                        _force_stop('ISA silent {:.0f}s after reconnect'.format(gap2))
+                                        return
+                                    _dbg('WATCHDOG OK on recheck -- ISA recovered')
                                 else:
                                     _dbg('WATCHDOG OK -- ISA still active')
+                                needs_force_stop = False
                                 return
                             time.sleep(2)
                         _dbg('GIVING UP after 15 attempts')
                     except Exception as ex:
-                        _dbg('RECONNECT THREAD CRASHED: {}'.format(ex))
-                    if not _proxy_state.get('stopping'):
-                        _force_stop('reconnect exhausted')
+                        try:
+                            _dbg('RECONNECT THREAD CRASHED: {}'.format(ex))
+                        except Exception:
+                            pass
+                    finally:
+                        if needs_force_stop and not _proxy_state.get('stopping'):
+                            try:
+                                _force_stop('reconnect exhausted')
+                            except Exception:
+                                pass
 
                 def _trigger_reconnect(reason):
                     with _proxy_state['lock']:
@@ -636,40 +677,62 @@ def Playvid(url, name):
 
                 srv = _S(('127.0.0.1', port), _H)
                 _cb_proxy = srv
+                _cb_proxy_state = _proxy_state
                 t = threading.Thread(target=srv.serve_forever)
                 t.daemon = True
                 t.start()
 
                 def _monitor_player():
                     """Poll xbmc.Player state and tear down the proxy when playback ends."""
+                    _dbg('MONITOR: thread started for port={}'.format(port))
+                    my_port_tag = ':{}/'.format(port)
                     try:
                         mon = xbmc.Monitor()
                         player = xbmc.Player()
-                        # Short grace window (8s) for ISA to actually begin playback
-                        started = False
-                        for _ in range(16):
+                        # Grace window (15s) for ISA to actually begin playing OUR URL.
+                        # We wait until getPlayingFile() actually points at us before
+                        # starting the watch-for-stop loop, otherwise a rapid click
+                        # would see the old stream's URL and immediately self-destruct.
+                        confirmed = False
+                        for _ in range(30):
                             if mon.abortRequested() or _proxy_state.get('stopping'):
                                 break
-                            if player.isPlaying():
-                                started = True
+                            try:
+                                cur = player.getPlayingFile() if player.isPlaying() else ''
+                            except Exception:
+                                cur = ''
+                            if cur and my_port_tag in cur:
+                                confirmed = True
                                 break
                             if mon.waitForAbort(0.5):
                                 break
-                        if not started:
-                            _dbg('MONITOR: playback never started within 8s, tearing down')
+                        if not confirmed:
+                            _dbg('MONITOR: never confirmed as active stream within 15s, tearing down')
                         else:
-                            _dbg('MONITOR: playback started, watching for stop')
+                            _dbg('MONITOR: confirmed active stream, watching for stop')
                             while not mon.abortRequested() and not _proxy_state.get('stopping'):
                                 if not player.isPlaying():
                                     _dbg('MONITOR: player stopped, shutting down proxy')
                                     break
-                                if mon.waitForAbort(2):
+                                # We already confirmed we're the active URL, so if
+                                # getPlayingFile now points elsewhere the user moved on.
+                                try:
+                                    cur = player.getPlayingFile()
+                                except Exception:
+                                    cur = ''
+                                if cur and my_port_tag not in cur:
+                                    _dbg('MONITOR: port={} no longer active (now {}), stopping'.format(port, cur))
+                                    break
+                                if mon.waitForAbort(1):
                                     break
                     except Exception as mex:
                         _dbg('MONITOR THREAD CRASHED: {}'.format(mex))
+                    _dbg('MONITOR: teardown entered addr={}'.format(
+                        getattr(srv, 'server_address', '?')))
                     _proxy_state['stopping'] = True
                     try:
                         srv.shutdown()
+                        _dbg('MONITOR: shutdown() OK')
                     except Exception as mex2:
                         _dbg('MONITOR: shutdown err {}'.format(mex2))
                     try:

--- a/plugin.video.cumination/resources/lib/sites/chaturbate.py
+++ b/plugin.video.cumination/resources/lib/sites/chaturbate.py
@@ -450,6 +450,8 @@ def Playvid(url, name):
                                             _dbg('PlayerControl(Stop) sent')
                                         except Exception as ex2:
                                             _dbg('PlayerControl(Stop) FAILED: {}'.format(ex2))
+                                        # give PlayerControl(Stop) time to work before killing proxy
+                                        time.sleep(3)
                                         try:
                                             _cb_proxy.shutdown()
                                             _dbg('Proxy server shutdown')

--- a/plugin.video.cumination/resources/lib/sites/chaturbate.py
+++ b/plugin.video.cumination/resources/lib/sites/chaturbate.py
@@ -290,15 +290,146 @@ def Playvid(url, name):
                     r'URI="(?!https?://)(.*?)"',
                     lambda m: 'URI="' + _urljoin(base, m.group(1)) + '"',
                     master_fixed, flags=re.IGNORECASE)
+                # Bind proxy port first so we can rewrite chunklist URLs
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.bind(('127.0.0.1', 0))
+                port = sock.getsockname()[1]
+                sock.close()
+
+                # State for session reconnection
+                _proxy_state = {
+                    'stream_url': m3u8stream,
+                    'headers': headers,
+                    'url_map': {},
+                    'last_refresh': 0,
+                    'lock': threading.Lock(),
+                }
+
+                # Populate initial chunklist URL map (type_key -> cdn_url)
+                for _line in master_fixed.splitlines():
+                    _line = _line.strip()
+                    if _line and not _line.startswith('#') and 'chunklist_' in _line:
+                        _km = re.search(r'(chunklist_\d+_\w+)', _line)
+                        if _km:
+                            _proxy_state['url_map'][_km.group(1)] = _line
+                for _mi in re.finditer(r'URI="(https?://[^"]*chunklist_[^"]*)"', master_fixed, re.IGNORECASE):
+                    _km = re.search(r'(chunklist_\d+_\w+)', _mi.group(1))
+                    if _km:
+                        _proxy_state['url_map'][_km.group(1)] = _mi.group(1)
+
+                # Rewrite only .m3u8 chunklist URLs to go through our proxy
+                # (leave init segments / .m4s files as direct CDN URLs)
+                master_fixed = re.sub(
+                    r'^(https?://[^\s]+\.m3u8[^\s]*)$',
+                    lambda m: 'http://127.0.0.1:{}/chunklist?url={}'.format(port, urllib_parse.quote(m.group(1), safe='')),
+                    master_fixed, flags=re.MULTILINE)
+                master_fixed = re.sub(
+                    r'URI="(https?://[^"]+\.m3u8[^"]*)"',
+                    lambda m: 'URI="http://127.0.0.1:{}/chunklist?url={}"'.format(port, urllib_parse.quote(m.group(1), safe='')),
+                    master_fixed, flags=re.IGNORECASE)
                 master_bytes = master_fixed.encode('utf-8')
 
+                def _refresh_session():
+                    """Re-fetch master playlist to get fresh session tokens."""
+                    now = time.time()
+                    with _proxy_state['lock']:
+                        if now - _proxy_state['last_refresh'] < 5:
+                            return False
+                        _proxy_state['last_refresh'] = now
+                    try:
+                        rq = _Req(_proxy_state['stream_url'], headers=_proxy_state['headers'])
+                        raw = _uopen(rq, timeout=10).read().decode('utf-8', 'replace')
+                        burl = _proxy_state['stream_url'].rsplit('/', 1)[0] + '/'
+                        fixed = re.sub(
+                            r'^(?!https?://)(?!#)(.+)$',
+                            lambda m: _urljoin(burl, m.group(1)),
+                            raw, flags=re.MULTILINE)
+                        fixed = re.sub(
+                            r'URI="(?!https?://)(.*?)"',
+                            lambda m: 'URI="' + _urljoin(burl, m.group(1)) + '"',
+                            fixed, flags=re.IGNORECASE)
+                        new_map = {}
+                        for line in fixed.splitlines():
+                            line = line.strip()
+                            if line and not line.startswith('#') and 'chunklist_' in line:
+                                km = re.search(r'(chunklist_\d+_\w+)', line)
+                                if km:
+                                    new_map[km.group(1)] = line
+                        for mi in re.finditer(r'URI="(https?://[^"]*chunklist_[^"]*)"', fixed, re.IGNORECASE):
+                            km = re.search(r'(chunklist_\d+_\w+)', mi.group(1))
+                            if km:
+                                new_map[km.group(1)] = mi.group(1)
+                        with _proxy_state['lock']:
+                            _proxy_state['url_map'].update(new_map)
+                        return True
+                    except Exception:
+                        return False
+
+                # Localhost proxy: serves master + proxies chunklists with auto-reconnect
                 class _H(BaseHTTPRequestHandler):
                     def do_GET(self):
-                        self.send_response(200)
-                        self.send_header('Content-Type', 'application/vnd.apple.mpegurl')
-                        self.send_header('Content-Length', str(len(master_bytes)))
-                        self.end_headers()
-                        self.wfile.write(master_bytes)
+                        if self.path.startswith('/chunklist'):
+                            parsed = urllib_parse.urlparse(self.path)
+                            params = urllib_parse.parse_qs(parsed.query)
+                            req_url = params.get('url', [None])[0]
+                            if not req_url:
+                                self.send_error(400)
+                                return
+                            km = re.search(r'(chunklist_\d+_\w+)', req_url)
+                            type_key = km.group(1) if km else None
+                            cdn_url = _proxy_state['url_map'].get(type_key, req_url) if type_key else req_url
+
+                            def _fetch_and_absolutize(u):
+                                """Fetch chunklist and absolutize relative URIs so ISA resolves them against CDN."""
+                                creq = _Req(u, headers=_proxy_state['headers'])
+                                resp = _uopen(creq, timeout=10)
+                                raw = resp.read().decode('utf-8', 'replace')
+                                cbase = u.rsplit('/', 1)[0] + '/'
+                                raw = re.sub(
+                                    r'^(?!https?://)(?!#)(\S+)$',
+                                    lambda m: _urljoin(cbase, m.group(1)),
+                                    raw, flags=re.MULTILINE)
+                                raw = re.sub(
+                                    r'URI="(?!https?://)([^"]+)"',
+                                    lambda m: 'URI="' + _urljoin(cbase, m.group(1)) + '"',
+                                    raw, flags=re.IGNORECASE)
+                                return raw.encode('utf-8')
+
+                            try:
+                                data = _fetch_and_absolutize(cdn_url)
+                                self.send_response(200)
+                                self.send_header('Content-Type', 'application/vnd.apple.mpegurl')
+                                self.send_header('Content-Length', str(len(data)))
+                                self.end_headers()
+                                self.wfile.write(data)
+                            except Exception:
+                                # CDN session died — try to get a fresh one
+                                if type_key and _refresh_session():
+                                    new_url = _proxy_state['url_map'].get(type_key)
+                                    if new_url and new_url != cdn_url:
+                                        try:
+                                            data = _fetch_and_absolutize(new_url)
+                                            self.send_response(200)
+                                            self.send_header('Content-Type', 'application/vnd.apple.mpegurl')
+                                            self.send_header('Content-Length', str(len(data)))
+                                            self.end_headers()
+                                            self.wfile.write(data)
+                                            return
+                                        except Exception:
+                                            pass
+                                # Reconnect failed — end stream gracefully
+                                endlist = b'#EXTM3U\n#EXT-X-ENDLIST\n'
+                                self.send_response(200)
+                                self.send_header('Content-Type', 'application/vnd.apple.mpegurl')
+                                self.send_header('Content-Length', str(len(endlist)))
+                                self.end_headers()
+                                self.wfile.write(endlist)
+                        else:
+                            self.send_response(200)
+                            self.send_header('Content-Type', 'application/vnd.apple.mpegurl')
+                            self.send_header('Content-Length', str(len(master_bytes)))
+                            self.end_headers()
+                            self.wfile.write(master_bytes)
                     def do_HEAD(self):
                         self.send_response(200)
                         self.send_header('Content-Type', 'application/vnd.apple.mpegurl')
@@ -310,10 +441,6 @@ def Playvid(url, name):
                     daemon_threads = True
                     allow_reuse_address = True
 
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                sock.bind(('127.0.0.1', 0))
-                port = sock.getsockname()[1]
-                sock.close()
                 srv = _S(('127.0.0.1', port), _H)
                 _cb_proxy = srv
                 t = threading.Thread(target=srv.serve_forever)

--- a/plugin.video.cumination/resources/lib/sites/chaturbate.py
+++ b/plugin.video.cumination/resources/lib/sites/chaturbate.py
@@ -393,6 +393,7 @@ def Playvid(url, name):
                             km = re.search(r'(chunklist_\d+_\w+)', req_url)
                             type_key = km.group(1) if km else None
                             cdn_url = _proxy_state['url_map'].get(type_key, req_url) if type_key else req_url
+                            _proxy_state['last_request'] = time.time()
 
                             def _fetch_and_absolutize(u):
                                 """Fetch chunklist and absolutize relative URIs so ISA resolves them against CDN."""
@@ -437,6 +438,21 @@ def Playvid(url, name):
                                 if not _proxy_state.get('reconnecting'):
                                     _dbg('CHUNKLIST FAIL type={} err={}'.format(type_key, e))
                                     _proxy_state['reconnecting'] = True
+
+                                    def _force_stop(reason):
+                                        _proxy_state['stopping'] = True
+                                        _dbg('FORCE STOP: {}'.format(reason))
+                                        try:
+                                            xbmc.executebuiltin('PlayerControl(Stop)')
+                                            _dbg('PlayerControl(Stop) sent')
+                                        except Exception as ex2:
+                                            _dbg('PlayerControl(Stop) FAILED: {}'.format(ex2))
+                                        try:
+                                            _cb_proxy.shutdown()
+                                            _dbg('Proxy server shutdown')
+                                        except Exception:
+                                            pass
+
                                     def _bg_reconnect():
                                         try:
                                             for _attempt in range(15):
@@ -444,18 +460,20 @@ def Playvid(url, name):
                                                 if _refresh_session():
                                                     _dbg('RECONNECT OK attempt={}'.format(_attempt + 1))
                                                     _proxy_state['reconnecting'] = False
+                                                    _dbg('WATCHDOG waiting 5s to check ISA')
+                                                    time.sleep(5)
+                                                    gap = time.time() - _proxy_state.get('last_request', 0)
+                                                    _dbg('WATCHDOG gap={:.1f}s'.format(gap))
+                                                    if gap > 4:
+                                                        _force_stop('ISA went silent {:.0f}s after reconnect'.format(gap))
+                                                    else:
+                                                        _dbg('WATCHDOG OK — ISA still active')
                                                     return
                                                 time.sleep(2)
                                             _dbg('GIVING UP after 15 attempts')
                                         except Exception as ex:
                                             _dbg('RECONNECT THREAD CRASHED: {}'.format(ex))
-                                        _proxy_state['stopping'] = True
-                                        _dbg('Sending PlayerControl(Stop)')
-                                        try:
-                                            xbmc.executebuiltin('PlayerControl(Stop)')
-                                            _dbg('PlayerControl(Stop) sent')
-                                        except Exception as ex2:
-                                            _dbg('PlayerControl(Stop) FAILED: {}'.format(ex2))
+                                        _force_stop('reconnect exhausted')
                                     t2 = threading.Thread(target=_bg_reconnect)
                                     t2.daemon = True
                                     t2.start()

--- a/plugin.video.cumination/resources/lib/sites/chaturbate.py
+++ b/plugin.video.cumination/resources/lib/sites/chaturbate.py
@@ -346,7 +346,7 @@ def Playvid(url, name):
                     """Re-fetch master playlist to get fresh session tokens."""
                     now = time.time()
                     with _proxy_state['lock']:
-                        if now - _proxy_state['last_refresh'] < 5:
+                        if now - _proxy_state['last_refresh'] < 2:
                             return False
                         _proxy_state['last_refresh'] = now
                     try:
@@ -418,36 +418,65 @@ def Playvid(url, name):
                                 self.end_headers()
                                 self.wfile.write(data)
                             except Exception as e:
-                                # CDN session died — retry reconnect for up to 30s
-                                _dbg('CHUNKLIST FAIL type={} err={}'.format(type_key, e))
-                                reconnected = False
-                                if type_key:
-                                    for _attempt in range(6):
-                                        _dbg('RECONNECT attempt={}/6 type={}'.format(_attempt + 1, type_key))
-                                        time.sleep(5)
-                                        if _refresh_session():
-                                            new_url = _proxy_state['url_map'].get(type_key)
-                                            if new_url:
-                                                try:
-                                                    data = _fetch_and_absolutize(new_url)
-                                                    self.send_response(200)
-                                                    self.send_header('Content-Type', 'application/vnd.apple.mpegurl')
-                                                    self.send_header('Content-Length', str(len(data)))
-                                                    self.end_headers()
-                                                    self.wfile.write(data)
-                                                    reconnected = True
-                                                    _dbg('RECONNECT OK attempt={} type={}'.format(_attempt + 1, type_key))
-                                                    break
-                                                except Exception as e2:
-                                                    _dbg('RECONNECT FETCH FAIL attempt={} err={}'.format(_attempt + 1, e2))
-                                if not reconnected:
-                                    _dbg('GIVING UP type={} — stopping playback'.format(type_key))
-                                    if not _proxy_state.get('stopping'):
+                                # If we already gave up, keep hammering stop
+                                if _proxy_state.get('stopping'):
+                                    _dbg('STOP REINFORCED (ISA still retrying)')
+                                    try:
+                                        xbmc.executebuiltin('PlayerControl(Stop)')
+                                    except Exception:
+                                        pass
+                                    endlist = b'#EXTM3U\n#EXT-X-ENDLIST\n'
+                                    self.send_response(200)
+                                    self.send_header('Content-Type', 'application/vnd.apple.mpegurl')
+                                    self.send_header('Content-Length', str(len(endlist)))
+                                    self.end_headers()
+                                    self.wfile.write(endlist)
+                                    return
+
+                                # CDN session died — kick off background reconnect
+                                if not _proxy_state.get('reconnecting'):
+                                    _dbg('CHUNKLIST FAIL type={} err={}'.format(type_key, e))
+                                    _proxy_state['reconnecting'] = True
+                                    def _bg_reconnect():
+                                        try:
+                                            for _attempt in range(15):
+                                                _dbg('RECONNECT attempt={}/15'.format(_attempt + 1))
+                                                if _refresh_session():
+                                                    _dbg('RECONNECT OK attempt={}'.format(_attempt + 1))
+                                                    _proxy_state['reconnecting'] = False
+                                                    return
+                                                time.sleep(2)
+                                            _dbg('GIVING UP after 15 attempts')
+                                        except Exception as ex:
+                                            _dbg('RECONNECT THREAD CRASHED: {}'.format(ex))
                                         _proxy_state['stopping'] = True
+                                        _dbg('Sending PlayerControl(Stop)')
                                         try:
                                             xbmc.executebuiltin('PlayerControl(Stop)')
+                                            _dbg('PlayerControl(Stop) sent')
+                                        except Exception as ex2:
+                                            _dbg('PlayerControl(Stop) FAILED: {}'.format(ex2))
+                                    t2 = threading.Thread(target=_bg_reconnect)
+                                    t2.daemon = True
+                                    t2.start()
+
+                                # While reconnecting, try serving from refreshed URLs
+                                if type_key and not _proxy_state.get('stopping'):
+                                    new_url = _proxy_state['url_map'].get(type_key)
+                                    if new_url and new_url != cdn_url:
+                                        try:
+                                            data = _fetch_and_absolutize(new_url)
+                                            self.send_response(200)
+                                            self.send_header('Content-Type', 'application/vnd.apple.mpegurl')
+                                            self.send_header('Content-Length', str(len(data)))
+                                            self.end_headers()
+                                            self.wfile.write(data)
+                                            _dbg('SERVED from refreshed URL type={}'.format(type_key))
+                                            return
                                         except Exception:
                                             pass
+
+                                # Return empty playlist — ISA retries quickly
                                 endlist = b'#EXTM3U\n#EXT-X-ENDLIST\n'
                                 self.send_response(200)
                                 self.send_header('Content-Type', 'application/vnd.apple.mpegurl')

--- a/plugin.video.cumination/resources/lib/sites/chaturbate.py
+++ b/plugin.video.cumination/resources/lib/sites/chaturbate.py
@@ -315,6 +315,7 @@ def Playvid(url, name):
                     'url_map': {},
                     'last_refresh': 0,
                     'lock': threading.Lock(),
+                    'chunklist_cache': {},
                 }
 
                 # Populate initial chunklist URL map (type_key -> cdn_url)
@@ -413,6 +414,8 @@ def Playvid(url, name):
 
                             try:
                                 data = _fetch_and_absolutize(cdn_url)
+                                if type_key:
+                                    _proxy_state['chunklist_cache'][type_key] = data
                                 self.send_response(200)
                                 self.send_header('Content-Type', 'application/vnd.apple.mpegurl')
                                 self.send_header('Content-Length', str(len(data)))
@@ -494,13 +497,22 @@ def Playvid(url, name):
                                         except Exception:
                                             pass
 
-                                # Return empty playlist — ISA retries quickly
-                                endlist = b'#EXTM3U\n#EXT-X-ENDLIST\n'
-                                self.send_response(200)
-                                self.send_header('Content-Type', 'application/vnd.apple.mpegurl')
-                                self.send_header('Content-Length', str(len(endlist)))
-                                self.end_headers()
-                                self.wfile.write(endlist)
+                                # Serve cached playlist to keep ISA alive during reconnect
+                                cached = _proxy_state['chunklist_cache'].get(type_key) if type_key else None
+                                if cached:
+                                    _dbg('SERVING CACHED playlist type={}'.format(type_key))
+                                    self.send_response(200)
+                                    self.send_header('Content-Type', 'application/vnd.apple.mpegurl')
+                                    self.send_header('Content-Length', str(len(cached)))
+                                    self.end_headers()
+                                    self.wfile.write(cached)
+                                else:
+                                    endlist = b'#EXTM3U\n#EXT-X-ENDLIST\n'
+                                    self.send_response(200)
+                                    self.send_header('Content-Type', 'application/vnd.apple.mpegurl')
+                                    self.send_header('Content-Length', str(len(endlist)))
+                                    self.end_headers()
+                                    self.wfile.write(endlist)
                         else:
                             self.send_response(200)
                             self.send_header('Content-Type', 'application/vnd.apple.mpegurl')

--- a/plugin.video.cumination/resources/lib/sites/chaturbate.py
+++ b/plugin.video.cumination/resources/lib/sites/chaturbate.py
@@ -272,6 +272,9 @@ def Playvid(url, name):
                 if _cb_proxy is not None:
                     try:
                         _cb_proxy.shutdown()
+                    except Exception:
+                        pass
+                    try:
                         _cb_proxy.server_close()
                     except Exception:
                         pass
@@ -395,10 +398,13 @@ def Playvid(url, name):
                     time.sleep(3)
                     try:
                         _cb_proxy.shutdown()
+                    except Exception as sex:
+                        _dbg('shutdown err: {}'.format(sex))
+                    try:
                         _cb_proxy.server_close()
                         _dbg('Proxy server shutdown')
-                    except Exception:
-                        pass
+                    except Exception as sex:
+                        _dbg('close err: {}'.format(sex))
 
                 def _bg_reconnect():
                     try:
@@ -409,7 +415,8 @@ def Playvid(url, name):
                             _dbg('RECONNECT attempt={}/15'.format(_attempt + 1))
                             if _refresh_session():
                                 _dbg('RECONNECT OK attempt={}'.format(_attempt + 1))
-                                _proxy_state['reconnecting'] = False
+                                with _proxy_state['lock']:
+                                    _proxy_state['reconnecting'] = False
                                 _dbg('WATCHDOG waiting 5s to check ISA')
                                 time.sleep(5)
                                 if _proxy_state.get('stopping'):
@@ -429,9 +436,10 @@ def Playvid(url, name):
                         _force_stop('reconnect exhausted')
 
                 def _trigger_reconnect(reason):
-                    if _proxy_state.get('reconnecting') or _proxy_state.get('stopping'):
-                        return
-                    _proxy_state['reconnecting'] = True
+                    with _proxy_state['lock']:
+                        if _proxy_state.get('reconnecting') or _proxy_state.get('stopping'):
+                            return
+                        _proxy_state['reconnecting'] = True
                     _dbg('RECONNECT TRIGGERED: {}'.format(reason))
                     t2 = threading.Thread(target=_bg_reconnect)
                     t2.daemon = True
@@ -662,10 +670,13 @@ def Playvid(url, name):
                     _proxy_state['stopping'] = True
                     try:
                         srv.shutdown()
-                        srv.server_close()
-                        _dbg('MONITOR: proxy shutdown complete')
                     except Exception as mex2:
                         _dbg('MONITOR: shutdown err {}'.format(mex2))
+                    try:
+                        srv.server_close()
+                        _dbg('MONITOR: proxy shutdown complete')
+                    except Exception as mex3:
+                        _dbg('MONITOR: close err {}'.format(mex3))
 
                 _mt = threading.Thread(target=_monitor_player)
                 _mt.daemon = True

--- a/plugin.video.cumination/resources/lib/sites/chaturbate.py
+++ b/plugin.video.cumination/resources/lib/sites/chaturbate.py
@@ -272,6 +272,7 @@ def Playvid(url, name):
                 if _cb_proxy is not None:
                     try:
                         _cb_proxy.shutdown()
+                        _cb_proxy.server_close()
                     except Exception:
                         pass
                     _cb_proxy = None
@@ -383,6 +384,59 @@ def Playvid(url, name):
                         _dbg('REFRESH FAIL {}'.format(e))
                         return False
 
+                def _force_stop(reason):
+                    _proxy_state['stopping'] = True
+                    _dbg('FORCE STOP: {}'.format(reason))
+                    try:
+                        xbmc.executebuiltin('PlayerControl(Stop)')
+                        _dbg('PlayerControl(Stop) sent')
+                    except Exception as ex2:
+                        _dbg('PlayerControl(Stop) FAILED: {}'.format(ex2))
+                    time.sleep(3)
+                    try:
+                        _cb_proxy.shutdown()
+                        _cb_proxy.server_close()
+                        _dbg('Proxy server shutdown')
+                    except Exception:
+                        pass
+
+                def _bg_reconnect():
+                    try:
+                        for _attempt in range(15):
+                            if _proxy_state.get('stopping'):
+                                _dbg('RECONNECT aborted - proxy stopping')
+                                return
+                            _dbg('RECONNECT attempt={}/15'.format(_attempt + 1))
+                            if _refresh_session():
+                                _dbg('RECONNECT OK attempt={}'.format(_attempt + 1))
+                                _proxy_state['reconnecting'] = False
+                                _dbg('WATCHDOG waiting 5s to check ISA')
+                                time.sleep(5)
+                                if _proxy_state.get('stopping'):
+                                    return
+                                gap = time.time() - _proxy_state.get('last_request', 0)
+                                _dbg('WATCHDOG gap={:.1f}s'.format(gap))
+                                if gap > 4:
+                                    _force_stop('ISA went silent {:.0f}s after reconnect'.format(gap))
+                                else:
+                                    _dbg('WATCHDOG OK -- ISA still active')
+                                return
+                            time.sleep(2)
+                        _dbg('GIVING UP after 15 attempts')
+                    except Exception as ex:
+                        _dbg('RECONNECT THREAD CRASHED: {}'.format(ex))
+                    if not _proxy_state.get('stopping'):
+                        _force_stop('reconnect exhausted')
+
+                def _trigger_reconnect(reason):
+                    if _proxy_state.get('reconnecting') or _proxy_state.get('stopping'):
+                        return
+                    _proxy_state['reconnecting'] = True
+                    _dbg('RECONNECT TRIGGERED: {}'.format(reason))
+                    t2 = threading.Thread(target=_bg_reconnect)
+                    t2.daemon = True
+                    t2.start()
+
                 # Localhost proxy: serves master + proxies chunklists with auto-reconnect
                 class _H(BaseHTTPRequestHandler):
                     def do_GET(self):
@@ -457,50 +511,8 @@ def Playvid(url, name):
                                     return
 
                                 # CDN session died — kick off background reconnect
-                                if not _proxy_state.get('reconnecting'):
-                                    _dbg('CHUNKLIST FAIL type={} err={}'.format(type_key, e))
-                                    _proxy_state['reconnecting'] = True
-
-                                    def _force_stop(reason):
-                                        _proxy_state['stopping'] = True
-                                        _dbg('FORCE STOP: {}'.format(reason))
-                                        try:
-                                            xbmc.executebuiltin('PlayerControl(Stop)')
-                                            _dbg('PlayerControl(Stop) sent')
-                                        except Exception as ex2:
-                                            _dbg('PlayerControl(Stop) FAILED: {}'.format(ex2))
-                                        # give PlayerControl(Stop) time to work before killing proxy
-                                        time.sleep(3)
-                                        try:
-                                            _cb_proxy.shutdown()
-                                            _dbg('Proxy server shutdown')
-                                        except Exception:
-                                            pass
-
-                                    def _bg_reconnect():
-                                        try:
-                                            for _attempt in range(15):
-                                                _dbg('RECONNECT attempt={}/15'.format(_attempt + 1))
-                                                if _refresh_session():
-                                                    _dbg('RECONNECT OK attempt={}'.format(_attempt + 1))
-                                                    _proxy_state['reconnecting'] = False
-                                                    _dbg('WATCHDOG waiting 5s to check ISA')
-                                                    time.sleep(5)
-                                                    gap = time.time() - _proxy_state.get('last_request', 0)
-                                                    _dbg('WATCHDOG gap={:.1f}s'.format(gap))
-                                                    if gap > 4:
-                                                        _force_stop('ISA went silent {:.0f}s after reconnect'.format(gap))
-                                                    else:
-                                                        _dbg('WATCHDOG OK — ISA still active')
-                                                    return
-                                                time.sleep(2)
-                                            _dbg('GIVING UP after 15 attempts')
-                                        except Exception as ex:
-                                            _dbg('RECONNECT THREAD CRASHED: {}'.format(ex))
-                                        _force_stop('reconnect exhausted')
-                                    t2 = threading.Thread(target=_bg_reconnect)
-                                    t2.daemon = True
-                                    t2.start()
+                                _dbg('CHUNKLIST FAIL type={} err={}'.format(type_key, e))
+                                _trigger_reconnect('chunklist fail type={}: {}'.format(type_key, e))
 
                                 # While reconnecting, try serving from refreshed URLs
                                 if type_key and not _proxy_state.get('stopping'):
@@ -542,6 +554,7 @@ def Playvid(url, name):
                                 self.send_error(400)
                                 return
                             seg_name = seg_url.rsplit('/', 1)[-1].split('?')[0]
+                            _proxy_state['last_request'] = time.time()
                             # Try the requested URL first
                             try:
                                 sreq = _Req(seg_url, headers=_proxy_state['headers'])
@@ -556,6 +569,7 @@ def Playvid(url, name):
                                 return
                             except Exception as e:
                                 _dbg('SEG FAIL {} {}'.format(seg_name, e))
+                                _trigger_reconnect('segment fail: {}'.format(seg_name))
                             # Fallback: try current CDN URL for same segment name
                             current_url = _proxy_state['seg_cdn_urls'].get(seg_name)
                             if current_url and current_url != seg_url:
@@ -617,6 +631,45 @@ def Playvid(url, name):
                 t = threading.Thread(target=srv.serve_forever)
                 t.daemon = True
                 t.start()
+
+                def _monitor_player():
+                    """Poll xbmc.Player state and tear down the proxy when playback ends."""
+                    try:
+                        mon = xbmc.Monitor()
+                        player = xbmc.Player()
+                        # Short grace window (8s) for ISA to actually begin playback
+                        started = False
+                        for _ in range(16):
+                            if mon.abortRequested() or _proxy_state.get('stopping'):
+                                break
+                            if player.isPlaying():
+                                started = True
+                                break
+                            if mon.waitForAbort(0.5):
+                                break
+                        if not started:
+                            _dbg('MONITOR: playback never started within 8s, tearing down')
+                        else:
+                            _dbg('MONITOR: playback started, watching for stop')
+                            while not mon.abortRequested() and not _proxy_state.get('stopping'):
+                                if not player.isPlaying():
+                                    _dbg('MONITOR: player stopped, shutting down proxy')
+                                    break
+                                if mon.waitForAbort(2):
+                                    break
+                    except Exception as mex:
+                        _dbg('MONITOR THREAD CRASHED: {}'.format(mex))
+                    _proxy_state['stopping'] = True
+                    try:
+                        srv.shutdown()
+                        srv.server_close()
+                        _dbg('MONITOR: proxy shutdown complete')
+                    except Exception as mex2:
+                        _dbg('MONITOR: shutdown err {}'.format(mex2))
+
+                _mt = threading.Thread(target=_monitor_player)
+                _mt.daemon = True
+                _mt.start()
 
                 videourl = 'http://127.0.0.1:{}/master.m3u8'.format(port)
             except Exception:

--- a/plugin.video.cumination/resources/lib/sites/chaturbate.py
+++ b/plugin.video.cumination/resources/lib/sites/chaturbate.py
@@ -316,6 +316,8 @@ def Playvid(url, name):
                     'last_refresh': 0,
                     'lock': threading.Lock(),
                     'chunklist_cache': {},
+                    'seg_cdn_urls': {},
+                    'latest_seg': {},
                 }
 
                 # Populate initial chunklist URL map (type_key -> cdn_url)
@@ -397,7 +399,7 @@ def Playvid(url, name):
                             _proxy_state['last_request'] = time.time()
 
                             def _fetch_and_absolutize(u):
-                                """Fetch chunklist and absolutize relative URIs so ISA resolves them against CDN."""
+                                """Fetch chunklist, absolutize relative URIs, and route segments through proxy."""
                                 creq = _Req(u, headers=_proxy_state['headers'])
                                 resp = _uopen(creq, timeout=10)
                                 raw = resp.read().decode('utf-8', 'replace')
@@ -409,6 +411,23 @@ def Playvid(url, name):
                                 raw = re.sub(
                                     r'URI="(?!https?://)([^"]+)"',
                                     lambda m: 'URI="' + _urljoin(cbase, m.group(1)) + '"',
+                                    raw, flags=re.IGNORECASE)
+                                # Track current CDN segment URLs for fallback
+                                for _l in raw.splitlines():
+                                    _l = _l.strip()
+                                    if _l and not _l.startswith('#') and '.m4s' in _l:
+                                        _sn = _l.rsplit('/', 1)[-1].split('?')[0]
+                                        _proxy_state['seg_cdn_urls'][_sn] = _l
+                                        if type_key:
+                                            _proxy_state['latest_seg'][type_key] = _l
+                                # Rewrite segment URLs to go through localhost proxy
+                                raw = re.sub(
+                                    r'^(https?://[^\s]+\.m4s[^\s]*)$',
+                                    lambda m: 'http://127.0.0.1:{}/segment?url={}'.format(port, urllib_parse.quote(m.group(1), safe='')),
+                                    raw, flags=re.MULTILINE)
+                                raw = re.sub(
+                                    r'URI="(https?://[^"]+\.m4s[^"]*)"',
+                                    lambda m: 'URI="http://127.0.0.1:{}/segment?url={}"'.format(port, urllib_parse.quote(m.group(1), safe='')),
                                     raw, flags=re.IGNORECASE)
                                 return raw.encode('utf-8')
 
@@ -515,6 +534,67 @@ def Playvid(url, name):
                                     self.send_header('Content-Length', str(len(endlist)))
                                     self.end_headers()
                                     self.wfile.write(endlist)
+                        elif self.path.startswith('/segment'):
+                            parsed = urllib_parse.urlparse(self.path)
+                            params = urllib_parse.parse_qs(parsed.query)
+                            seg_url = params.get('url', [None])[0]
+                            if not seg_url:
+                                self.send_error(400)
+                                return
+                            seg_name = seg_url.rsplit('/', 1)[-1].split('?')[0]
+                            # Try the requested URL first
+                            try:
+                                sreq = _Req(seg_url, headers=_proxy_state['headers'])
+                                sresp = _uopen(sreq, timeout=10)
+                                data = sresp.read()
+                                ct = sresp.headers.get('Content-Type', 'video/mp4')
+                                self.send_response(200)
+                                self.send_header('Content-Type', ct)
+                                self.send_header('Content-Length', str(len(data)))
+                                self.end_headers()
+                                self.wfile.write(data)
+                                return
+                            except Exception as e:
+                                _dbg('SEG FAIL {} {}'.format(seg_name, e))
+                            # Fallback: try current CDN URL for same segment name
+                            current_url = _proxy_state['seg_cdn_urls'].get(seg_name)
+                            if current_url and current_url != seg_url:
+                                try:
+                                    sreq = _Req(current_url, headers=_proxy_state['headers'])
+                                    sresp = _uopen(sreq, timeout=10)
+                                    data = sresp.read()
+                                    ct = sresp.headers.get('Content-Type', 'video/mp4')
+                                    self.send_response(200)
+                                    self.send_header('Content-Type', ct)
+                                    self.send_header('Content-Length', str(len(data)))
+                                    self.end_headers()
+                                    self.wfile.write(data)
+                                    _dbg('SEG FALLBACK OK {}'.format(seg_name))
+                                    return
+                                except Exception as e2:
+                                    _dbg('SEG FALLBACK FAIL {}'.format(e2))
+                            # Last resort: serve the latest known segment for this track
+                            tm = re.search(r'(video|audio)_(\d+)_llhls', seg_name)
+                            if tm:
+                                for tk, latest in _proxy_state['latest_seg'].items():
+                                    if tm.group(1) in tk and tm.group(2) in tk:
+                                        try:
+                                            sreq = _Req(latest, headers=_proxy_state['headers'])
+                                            sresp = _uopen(sreq, timeout=10)
+                                            data = sresp.read()
+                                            ct = sresp.headers.get('Content-Type', 'video/mp4')
+                                            self.send_response(200)
+                                            self.send_header('Content-Type', ct)
+                                            self.send_header('Content-Length', str(len(data)))
+                                            self.end_headers()
+                                            self.wfile.write(data)
+                                            _dbg('SEG LATEST OK {}'.format(seg_name))
+                                            return
+                                        except Exception as e3:
+                                            _dbg('SEG LATEST FAIL {}'.format(e3))
+                                            break
+                            self.send_error(502)
+                            return
                         else:
                             self.send_response(200)
                             self.send_header('Content-Type', 'application/vnd.apple.mpegurl')

--- a/plugin.video.cumination/resources/lib/sites/chaturbate.py
+++ b/plugin.video.cumination/resources/lib/sites/chaturbate.py
@@ -403,21 +403,34 @@ def Playvid(url, name):
                                 self.end_headers()
                                 self.wfile.write(data)
                             except Exception:
-                                # CDN session died — try to get a fresh one
-                                if type_key and _refresh_session():
-                                    new_url = _proxy_state['url_map'].get(type_key)
-                                    if new_url and new_url != cdn_url:
+                                # CDN session died — retry reconnect for up to 30s
+                                # (covers stream switches where new origin takes a moment)
+                                reconnected = False
+                                if type_key:
+                                    for _attempt in range(6):
+                                        time.sleep(5)
+                                        if _refresh_session():
+                                            new_url = _proxy_state['url_map'].get(type_key)
+                                            if new_url:
+                                                try:
+                                                    data = _fetch_and_absolutize(new_url)
+                                                    self.send_response(200)
+                                                    self.send_header('Content-Type', 'application/vnd.apple.mpegurl')
+                                                    self.send_header('Content-Length', str(len(data)))
+                                                    self.end_headers()
+                                                    self.wfile.write(data)
+                                                    reconnected = True
+                                                    break
+                                                except Exception:
+                                                    pass
+                                if not reconnected:
+                                    # All retries exhausted — force stop playback
+                                    if not _proxy_state.get('stopping'):
+                                        _proxy_state['stopping'] = True
                                         try:
-                                            data = _fetch_and_absolutize(new_url)
-                                            self.send_response(200)
-                                            self.send_header('Content-Type', 'application/vnd.apple.mpegurl')
-                                            self.send_header('Content-Length', str(len(data)))
-                                            self.end_headers()
-                                            self.wfile.write(data)
-                                            return
+                                            xbmc.executebuiltin('PlayerControl(Stop)')
                                         except Exception:
                                             pass
-                                # Reconnect failed — end stream gracefully
                                 endlist = b'#EXTM3U\n#EXT-X-ENDLIST\n'
                                 self.send_response(200)
                                 self.send_header('Content-Type', 'application/vnd.apple.mpegurl')


### PR DESCRIPTION
hey, follow up to the prefetch fix in #1817

so the prefetch proxy solved the single-use master playlist problem but theres another issue - when the cdn session expires after awhile (or the model switches from live to prerecorded content), the chunklists start 403ing and isa goes into a tight retry loop that completely locks up kodi. cant even back out of the player

this extends the proxy to also handle chunklist requests so we can detect when the session dies and deal with it properly:

- proxies chunklist fetches through localhost, absolutizes relative URIs in the response so isa still resolves init segments and media segments against the cdn
- when chunklists start failing, re-fetches the master playlist from chaturbate to get fresh session tokens and maps them back to the right tracks
- retries reconnect every 5s for up to 30s to cover stream transitions (model switching content etc)
- if the model actually went offline and all retries fail, forces kodi to stop playback cleanly via PlayerControl instead of leaving it frozen
- added optional debug logging behind the existing enh_debug setting, writes to cb_proxy.log in kodi temp folder

still testing this out and debugging on my box so marking as draft for now, will keep pushing updates as i work through edge cases. wanted to get the PR up so yall can see whats coming

tested on kodi 22 / libreelec 13 with inputstream.adaptive