### PR TITLE
chaturbate - py2 import shim for the chunklist proxy

### DIFF
--- a/plugin.video.cumination/resources/lib/sites/chaturbate.py
+++ b/plugin.video.cumination/resources/lib/sites/chaturbate.py
@@ -262,8 +262,15 @@ def Playvid(url, name):
     if playmode == 0:
         if m3u8stream:
             import socket, threading, gzip, zlib  # noqa: E401
-            from http.server import BaseHTTPRequestHandler
-            from socketserver import TCPServer, ThreadingMixIn
+            # py2 (kodi 18.x leia) doesnt have http.server / socketserver,
+            # those are py3 names. fall back to py2 names so the proxy
+            # imports cleanly on older builds. issue #1845
+            try:
+                from http.server import BaseHTTPRequestHandler
+                from socketserver import TCPServer, ThreadingMixIn
+            except ImportError:
+                from BaseHTTPServer import BaseHTTPRequestHandler
+                from SocketServer import TCPServer, ThreadingMixIn
             from six.moves.urllib.request import Request as _Req, urlopen as _uopen
             from six.moves.urllib.parse import urljoin as _urljoin
 


### PR DESCRIPTION
## Summary
The chunklist proxy I added in #1818 imports from `http.server` and `socketserver`, which are py3 names. on kodi 18.x leia those modules dont exist (theyre `BaseHTTPServer` and `SocketServer` in py2) so the import bombs before the proxy can even start.

wrap the imports in try/except so py3 takes the new names and py2 falls back to the old ones. `BaseHTTPRequestHandler`, `TCPServer`, and `ThreadingMixIn` have the same api in both so nothing else needs to change.

fixes #1845, should also help #1823 (the em dash was the first crash, this is the second one a few lines later).

## Test plan
i dont have a kodi 18.x box handy so this is a paper fix based on @pitsi's traceback. would be great if someone running 18.x leia could try it on a couple of rooms before merging. the py3 path is unchanged so 19+ shouldnt see any difference.