### PR TITLE
chaturbate - dont stop the player if its on a different proxy

### DIFF
--- a/plugin.video.cumination/resources/lib/sites/chaturbate.py
+++ b/plugin.video.cumination/resources/lib/sites/chaturbate.py
@@ -431,11 +431,20 @@ def Playvid(url, name):
                 def _force_stop(reason):
                     _proxy_state['stopping'] = True
                     _dbg('FORCE STOP: {}'.format(reason))
+                    # skip the global Stop if player moved to another proxy
+                    # (sibling playvid). still tear our own proxy down below.
                     try:
-                        xbmc.executebuiltin('PlayerControl(Stop)')
-                        _dbg('PlayerControl(Stop) sent')
-                    except Exception as ex2:
-                        _dbg('PlayerControl(Stop) FAILED: {}'.format(ex2))
+                        cur = xbmc.Player().getPlayingFile() or ''
+                    except Exception:
+                        cur = ''
+                    if cur and ':{}/'.format(port) not in cur:
+                        _dbg('PlayerControl(Stop) skipped, player on diff proxy {}'.format(cur))
+                    else:
+                        try:
+                            xbmc.executebuiltin('PlayerControl(Stop)')
+                            _dbg('PlayerControl(Stop) sent')
+                        except Exception as ex2:
+                            _dbg('PlayerControl(Stop) FAILED: {}'.format(ex2))
                     time.sleep(3)
                     try:
                         _cb_proxy.shutdown()


### PR DESCRIPTION
i think the disconnects in #1834 are PlayerControl(Stop) firing on
the wrong player.

each playvid runs in its own python process so port and _proxy_state
dont share. open room A then room B, room A's proxy is still alive
in process A. when its reconnect dies a few seconds later it fires
_force_stop. but the player is on room B's proxy by now so the stop
kills room B.

before firing stop, check getPlayingFile() and skip if our port isnt
in the url. the monitor thread already does the same check around
line 749.

would be alot of help if someone hitting this can test before merge.
not 100% sure i caught every stop path. if it doesnt help id rather
revert than leave a half fix in.